### PR TITLE
Minor Fix to make the code compile with newer version of tensorflow

### DIFF
--- a/sbnet_tensorflow/benchmark/tf_conv_dims_tests.py
+++ b/sbnet_tensorflow/benchmark/tf_conv_dims_tests.py
@@ -87,7 +87,7 @@ class CalcPaddingTests(tf.test.TestCase):
         try:
             calc_padding_4d(tf.shape(x), [2, 3, 1, 1, 1], [2, 1, 1, 1], 'SAME')
         except AssertionError as e:
-            self.assertEqual(e.message, 'Expect `ksize` a list/tuple of length 4.')
+            self.assertEqual(e.args[0], 'Expect `ksize` a list/tuple of length 4.')
             err_raised = True
         self.assertTrue(err_raised)
 
@@ -98,7 +98,7 @@ class CalcPaddingTests(tf.test.TestCase):
         try:
             calc_padding_4d(tf.shape(x), [2, 3, 1, 1], [2, 1, 1, 1], 'SAME')
         except AssertionError as e:
-            self.assertEqual(e.message, 'Expect first and last dimension of `strides` = 1.')
+            self.assertEqual(e.args[0], 'Expect first and last dimension of `strides` = 1.')
             err_raised = True
         self.assertTrue(err_raised)
 

--- a/sbnet_tensorflow/sbnet_ops/sparse_gather.cc
+++ b/sbnet_tensorflow/sbnet_ops/sparse_gather.cc
@@ -155,7 +155,7 @@ public:
         OP_REQUIRES_OK(context, context->GetAttr("boffset", &boffset));
         OP_REQUIRES(context,
             bsize.size() == 2 && bstride.size() == 2 && boffset.size() == 2,
-            errors::InvalidArgument("All block attributes must have a shape of (2,)."))
+            errors::InvalidArgument("All block attributes must have a shape of (2,)."));
         OP_REQUIRES_OK(context, context->GetAttr("transpose", &transpose_));
 
         bSzH_    = bsize[0];   bSzW_ = bsize[1];
@@ -278,7 +278,7 @@ public:
         OP_REQUIRES_OK(context, context->GetAttr("boffset", &boffset));
         OP_REQUIRES(context,
             bsize.size() == 2 && bstride.size() == 2 && boffset.size() == 2,
-            errors::InvalidArgument("All block attributes must have a shape of (2,)."))
+            errors::InvalidArgument("All block attributes must have a shape of (2,)."));
         bSzH_    = bsize[0];   bSzW_ = bsize[1];
         bStrH_   = bstride[0]; bStrW_ = bstride[1];
         bOffsH0_ = boffset[0]; bOffsW0_ = boffset[1];


### PR DESCRIPTION
OP_REQUIRES macro has changed since tensorflow version 1.5
The expression requires a semicolon postfix